### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/auth-request.js
+++ b/lib/auth-request.js
@@ -4,7 +4,7 @@ var KeyEncoder = require('key-encoder'),
     TokenSigner = require('jwt-js').TokenSigner,
     decodeToken = require('jwt-js').decodeToken,
     secp256k1 = require('elliptic-curve').secp256k1,
-    uuid = require('node-uuid')
+    uuid = require('uuid')
 
 function AuthRequest(privateKey) {
     this.privateKey = privateKey

--- a/lib/auth-response.js
+++ b/lib/auth-response.js
@@ -4,7 +4,7 @@ var KeyEncoder = require('key-encoder'),
     TokenSigner = require('jwt-js').TokenSigner,
     decodeToken = require('jwt-js').decodeToken,
     secp256k1 = require('elliptic-curve').secp256k1,
-    uuid = require('node-uuid')
+    uuid = require('uuid')
 
 function AuthResponse(privateKey) {
     this.privateKey = privateKey

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "jwt-js": "^0.4.2",
     "key-encoder": "^1.1.3",
     "keychain-manager": "^1.1.2",
-    "node-uuid": "^1.4.3",
-    "promise": "^7.0.4"
+    "promise": "^7.0.4",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "onename-api": "^1.0.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.